### PR TITLE
120469 updated dehydrated

### DIFF
--- a/src/batou_ext/ssl.py
+++ b/src/batou_ext/ssl.py
@@ -57,8 +57,8 @@ class Certificate(batou.component.Component):
     # Let's Encrypt
     dehydrated_url = (
         "https://raw.githubusercontent.com/lukas2511/dehydrated"
-        "/74a536c16178312845503caa5322c19de34b2dca/dehydrated")
-    dehydrated_checksum = 'md5:ff538eb0509b8d9c76307702748dec63'
+        "/e2eeaf7ec6932cdcea1e82b68630ac98a331f571/dehydrated")
+    dehydrated_checksum = 'md5:13aa69c790565f0ed881bff3df301055'
 
     extracommand = None
 

--- a/src/batou_ext/ssl.py
+++ b/src/batou_ext/ssl.py
@@ -81,7 +81,7 @@ class Certificate(batou.component.Component):
 
     use_letsencrypt = batou.component.Attribute('literal', True)
 
-    letsencrypt_ca = "https://acme-v01.api.letsencrypt.org/directory"
+    letsencrypt_ca = "https://acme-v02.api.letsencrypt.org/directory"
     letsencrypt_challange = "http-01"
     letsencrypt_hook = ""
 


### PR DESCRIPTION
Update dehydrated and switch to ACME v2 API endpoint. 
Letsencrypt ACME v1 API is deprecated and will be shut down over the next months. Since November 2019 account registration has been disabled.