### PR TITLE
Improve error handling on cronjob

### DIFF
--- a/src/batou_ext/cron.py
+++ b/src/batou_ext/cron.py
@@ -73,7 +73,7 @@ class CronJob(batou.component.Component):
         self.wrapped_command = self._.path
 
         if self.checkWarning or self.checkCritical:
-            cmd = ["-i -f", self.stamp_file]
+            cmd = ["-f", self.stamp_file]
             if self.checkWarning:
                 cmd.append("-w")
                 cmd.append(str(int(self.checkWarning) * 60))

--- a/src/batou_ext/cron.py
+++ b/src/batou_ext/cron.py
@@ -59,6 +59,10 @@ class CronJob(batou.component.Component):
         self.lock_file = self.map(self.expand(".{{component.tag}}.lock"))
         self.stamp_file = self.map(self.expand(".{{component.tag}}.stamp"))
 
+        # Ensure, we do have the stamp file there so the sensu-check is
+        # getting red if next runs are not successful
+        self += batou.lib.file.File(self.stamp_file, content="")
+
         self += batou.lib.file.File(
             self.expand("{{component.tag}}.sh"),
             content=pkg_resources.resource_string(


### PR DESCRIPTION
cron.CronJob is having a bootstrapping issue: In case of a cronjob never runs correctly, the connected service check keeps on not finding any error. This PR is intended to fix that issue.