### PR TITLE
Geoip download: Make URL support licence_key and be configurable

### DIFF
--- a/src/batou_ext/geoip.py
+++ b/src/batou_ext/geoip.py
@@ -16,6 +16,10 @@ class GeoIPDatabase(batou.component.Component):
 
     Needs curl and gunzip inside $PATH
     """
+    license_key = None
+    download_url = batou.component.Attribute(
+        str,
+        "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&suffix=tar.gz&license_key={{component.license_key}}")
 
     def configure(self):
 

--- a/src/batou_ext/resources/geoip-update.sh
+++ b/src/batou_ext/resources/geoip-update.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env sh
 
+set -e
+
 {% if component.host.platform == "nixos" -%}
 source /etc/profile
 {% endif -%}
 
-curl -O http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz
-gunzip -f GeoLite2-City.mmdb.gz
+cd {{component.workdir}}
+curl -s "{{component.download_url}}" | tar -xzv --strip-components 1


### PR DESCRIPTION
After upstream changed way on distributing the database, this PR is adjusting the URL and adds support of a licence key. 