### PR TITLE
Use the current *local* rev for updating batou_ext instead of remote …

### DIFF
--- a/bin/update_batouext
+++ b/bin/update_batouext
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ext_dir=$(dirname $0)/../.git
-rev=$(git --git-dir ${ext_dir} ls-remote origin refs/heads/master | awk '{print $1}')
+rev=$(git rev-parse HEAD)
 
 pip3 download --quiet --no-deps https://github.com/flyingcircusio/batou_ext/archive/${rev}.zip
 checksum=$(pip3 hash ${rev}.zip | grep -- '--hash' | cut -d: -f2)


### PR DESCRIPTION
…master

It happens that you need a branch of batou_ext in a deployment. This way it will just use whatever you have locally.