### PR TITLE
Ensure service_user is set when using logrotate on NixOS

### DIFF
--- a/src/batou_ext/nix.py
+++ b/src/batou_ext/nix.py
@@ -378,6 +378,8 @@ class SensuChecks(batou.component.Component):
 @batou.component.platform("nixos", batou.lib.logrotate.Logrotate)
 class LogrotateIntegration(batou.component.Component):
     def configure(self):
+        assert self.environment.service_user, (
+            "Need to set service_user inside environment file.")
         user = self.environment.service_user
         user_logrotate_conf = os.path.join("/etc/local/logrotate", user, "batou.conf")
         self += batou.lib.file.File(


### PR DESCRIPTION
Catch if there is no service_user defined in environment file at logrotate on NixOS

We later depend on the set user so we have to ensure it's really set at this point