### PR TITLE
ssl.Certificate(): Ensure alternative_names is a tuple or a list

### DIFF
--- a/src/batou_ext/ssl.py
+++ b/src/batou_ext/ssl.py
@@ -93,6 +93,8 @@ class Certificate(batou.component.Component):
     _may_need_to_generate_certificates = False
 
     def configure(self):
+        if not isinstance(self.alternative_names, (tuple, list)):
+            raise ValueError('"alternative_names" needs to be a tuple of string.')
         if not self.refresh_timing:
             h = int(hashlib.md5(
                 six.ensure_binary(self.domain, "UTF-8")).hexdigest(), 16)


### PR DESCRIPTION
We have seen issues with (buggy) code pasting a FQDN as simple string
to alternative_name which caused errors during the deployment.

Change's goal is to prevent such cases.

Fixes #24