### PR TITLE
Allow umlauts in description for provisioning/diff

### DIFF
--- a/src/batou_ext/fcio.py
+++ b/src/batou_ext/fcio.py
@@ -211,7 +211,7 @@ class Provision(batou.component.Component):
                 rbd_pool=d.get("rbdpool", "rbd.hdd"),
                 frontend_ips_v4=int(d.get("frontend-ipv4", 0)),
                 frontend_ips_v6=int(d.get("frontend-ipv6", 0)),
-                service_description=d.get("description", ""),
+                service_description=d.get("description", "").decode('UTF-8'),
             )
 
             def alias(interface):


### PR DESCRIPTION
Generally the configuration should be parsed as utf8, but that's to be changed in batou. Also this is batou1/py2 so I'm not going to invest too much here. It's likely failing in batou2, too, though.

bugs id: #124807