### PR TITLE
Compatibility for batou 2.1

### DIFF
--- a/src/batou_ext/cron.py
+++ b/src/batou_ext/cron.py
@@ -29,6 +29,7 @@ class CronJob(batou.component.Component):
     Ensure this values are fitting the settings done within `timing`.
     """
 
+    timing = None
     log_file = None
     lock_file = None
     stamp_file = None

--- a/src/batou_ext/nix.py
+++ b/src/batou_ext/nix.py
@@ -171,6 +171,12 @@ def rebuild(cls):
     return cls
 
 
+# Uhugh. Patch service so we can set checksum/systemd data which is being used
+# by UserInit.
+batou.lib.service.Service.checksum = None
+batou.lib.service.Service.systemd = None
+
+
 @batou.component.platform("nixos", batou.lib.service.Service)
 class UserInit(batou.component.Component):
     """Start services on fc platform.
@@ -299,6 +305,11 @@ class InstallCrontab(batou.lib.cron.InstallCrontab):
 
     def update(self):
         self.cmd(self.expand("cat {{component.crontab.path}} | crontab -"))
+
+
+# Patch Service so we can pass down the name to sensu
+batou.lib.nagios.Service.name: str = None
+batou.lib.nagios.Service.interval: int = None
 
 
 @rebuild

--- a/src/batou_ext/postgres.py
+++ b/src/batou_ext/postgres.py
@@ -83,6 +83,7 @@ class User(PostgresDataComponent):
 
     namevar = 'name'
     flags = 'NOCREATEDB NOCREATEROLE NOSUPERUSER'
+    password: str = None
 
     def configure(self):
         super(User, self).configure()

--- a/src/batou_ext/ssh.py
+++ b/src/batou_ext/ssh.py
@@ -1,6 +1,6 @@
 from batou import UpdateNeeded
 from batou.component import Component, Attribute
-from batou.lib.file import Directory, File, Purge
+from batou.lib.file import File, Purge
 import os
 import os.path
 
@@ -28,7 +28,7 @@ class SSHKeyPair(Component):
         if self.provide_itself:
             self.provide('sshkeypair', self)
 
-        self += Directory('~/.ssh', mode=0o700)
+        self += File('~/.ssh', ensure='directory', mode=0o700)
 
         # RSA
         if self.id_rsa:

--- a/src/batou_ext/ssl.py
+++ b/src/batou_ext/ssl.py
@@ -217,6 +217,8 @@ openssl x509 -req -days 3650 \
 
 class ActivateLetsEncrypt(batou.component.Component):
 
+    cert: Certificate = None
+
     def verify(self):
         if self.cert.use_letsencrypt:
             self.cert.assert_no_subcomponent_changes()


### PR DESCRIPTION
Batou recently got the strict validation of parameters to components. This leads to surprising things as we – of course – used to pass down parameters which are otherwise unknown to batou. See e.g. 9c155d9 and 03a56b2. This works but doesn't seem pretty. So let's discuss what a more obvious and clean way of passing more information/parameters than anticipated.