### PR TITLE
Fix unicode handling on dependency_strings at PHP-FPM

### DIFF
--- a/src/batou_ext/php.py
+++ b/src/batou_ext/php.py
@@ -89,7 +89,10 @@ class FPM(batou.component.Component):
     def configure(self):
         self._checksum = hashlib.new("sha256")
         for s in self.dependency_strings:
-            self._checksum.update(s)
+            if isinstance(s, str):
+                self._checksum.update(s.encode("utf-8"))
+            else:
+                self._checksum.update(s)
 
         self.address = batou.utils.Address(self.host.fqdn, self.port)
 


### PR DESCRIPTION
We are using a checksum to determine wether e.g. NixOS needs to reload the unit file created by this component.