### PR TITLE
update supported Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,14 +31,13 @@ setup(
     classifiers="""\
 License :: OSI Approved :: BSD License
 Programming Language :: Python
-Programming Language :: Python :: 2
-Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
+Programming Language :: Python :: 3 :: Only
 """[:-1].split('\n'),
     description=__doc__.strip(),
     long_description='\n\n'.join(open(project_path(name)).read() for name in (

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,12 @@ License :: OSI Approved :: BSD License
 Programming Language :: Python
 Programming Language :: Python :: 2
 Programming Language :: Python :: 2.7
-Programming Language :: Python :: 2 :: Only
+Programming Language :: Python :: 3
+Programming Language :: Python :: 3.5
+Programming Language :: Python :: 3.6
+Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
+Programming Language :: Python :: 3.9
 """[:-1].split('\n'),
     description=__doc__.strip(),
     long_description='\n\n'.join(open(project_path(name)).read() for name in (


### PR DESCRIPTION
this is a wild guess, as there is no test suite...

I took the versions over from batou - although I did not remove Python 2.7 support.

I run batou and batou_ext on Python 3.10.0a - for reasons :-) And I have no language version related issues.