### PR TITLE
ssh.SSHKeyPair: Add additional \n after key to avoid invalid key format

### DIFF
--- a/src/batou_ext/ssh.py
+++ b/src/batou_ext/ssh.py
@@ -34,7 +34,7 @@ class SSHKeyPair(Component):
         # RSA
         if self.id_rsa:
             self += File('~/.ssh/id_rsa',
-                         content=(self.id_rsa + "\n"),
+                         content=(self.id_rsa + '\n'),
                          mode=0o600,
                          sensitive_data=True)
         elif self.purge_unmanaged_keys:

--- a/src/batou_ext/ssh.py
+++ b/src/batou_ext/ssh.py
@@ -34,7 +34,7 @@ class SSHKeyPair(Component):
         # RSA
         if self.id_rsa:
             self += File('~/.ssh/id_rsa',
-                         content=self.id_rsa,
+                         content=(self.id_rsa + "\n"),
                          mode=0o600,
                          sensitive_data=True)
         elif self.purge_unmanaged_keys:


### PR DESCRIPTION
RSA key needs an explicit \n at the end of the key file. 