### PR TITLE
Postgres.DB: Allow to set a template for creation of a new db

### DIFF
--- a/src/batou_ext/postgres.py
+++ b/src/batou_ext/postgres.py
@@ -47,6 +47,7 @@ class DB(PostgresDataComponent):
 
     namevar = 'db'
     locale = 'en_US.UTF-8'
+    template = 'template1'
     owner = None
 
     def configure(self):
@@ -66,7 +67,7 @@ class DB(PostgresDataComponent):
     def update(self):
         self.pgcmd(
             self.expand(
-                'createdb -l {{component.locale}} -O "{{component.owner}}" '
+                'createdb -T {{component.template}} -l {{component.locale}} -O "{{component.owner}}" '
                 '"{{component.db}}"'))
 
 


### PR DESCRIPTION
Usually PostgreSQL is using `template1` for creation of new db. In some cases we need to make usage of `template0` or even give our very own template. This change aims to help in such cases. 