### PR TITLE
Draft to ensure that services that were manually deactivated are started with a deployment (convergence).

### DIFF
--- a/src/batou_ext/nix.py
+++ b/src/batou_ext/nix.py
@@ -267,6 +267,12 @@ class UserInit(batou.component.Component):
     def start(self):
         self.cmd("sudo systemctl start {}".format(self.name))
 
+    def verify(self):
+        self.assert_cmd("sudo systemctl is-active {}".format(self.name))
+
+    def update(self):
+        self.start()
+
 
 @batou.component.platform("nixos", batou.lib.supervisor.RunningSupervisor)
 class FixSupervisorStartedBySystemd(batou.component.Component):


### PR DESCRIPTION
As discussed with @frlan we're currently not re-activating services based on systemd during a deployment if no change was in the deployment but someone deactivated the service manually.