### PR TITLE
Nix: Enable package deletion without specifying version

### DIFF
--- a/src/batou_ext/nix.py
+++ b/src/batou_ext/nix.py
@@ -70,9 +70,11 @@ class PurgePackage(batou.component.Component):
     namevar = "package"
 
     def verify(self):
-        stdout, stderr = self.cmd("nix-env --query")
-        if self.package in stdout.splitlines():
+        try:
+            self.cmd("nix-env --query {{component.package}}")
             raise batou.UpdateNeeded()
+        except batou.utils.CmdExecutionError:
+            pass
 
     def update(self):
         self.cmd("nix-env --uninstall {{component.package}}")


### PR DESCRIPTION
Currently if you want to delete a package with `PurgePackage` you have to exactly specify the package name and version, because it tests against the output of `nix-env --query`. An example output:
```
nichmoe@machine % nix-env --query
cmake-3.21.2
coreutils-8.32
emacs-27.2
```
If you would want to ensure that cmake is not installed you would have to use `PurgePackage('cmake-3.21.2')` which will only delete cmake on version 3.21.2. 

Now `PurgePackage` does not require the version, because it only tests if the package is installed regardless of version. It tests if `nix-env --query $PACKAGE` has exitcode 0 and does not care about the output:
```
nichmoe@machine % nix-env --query cmake
cmake-3.21.2
```

This behavior does not break compatibility with previous versions, it still deletes the package, if the full package name with version is given.