### PR TITLE
run.Run(): Add stampfile 

### DIFF
--- a/src/batou_ext/run.py
+++ b/src/batou_ext/run.py
@@ -41,6 +41,8 @@ class Run(batou.component.Component):
 
     def verify(self):
         self.parent.assert_no_changes()
+        self.assert_file_is_current(f'{self.command_file.path}_stamp', requirements=[f'{self.command_file.path}',])
 
     def update(self):
         self.cmd(self.command_file.path)
+        self.touch(f'{self.command_file.path}_stamp')


### PR DESCRIPTION
We have seen cases when the script executed with `Run()` ended in a failure due to external reasons (e.g. a download source was not available). But reexecuting the deployment did not restart the script. This MR intents to improve it by adding a stamp after (successfully) execution and re-execution `Run()`until the stamp-file is present.