### PR TITLE
Add a component to make it easier to configure a journalbeat on our N…

### DIFF
--- a/src/batou_ext/journalbeat.py
+++ b/src/batou_ext/journalbeat.py
@@ -1,0 +1,21 @@
+import batou.component
+import batou.lib.file
+import pkg_resources
+
+
+class JournalBeatTransport(batou.component.Component):
+
+    """ A shortcut for sending logmessages via journalbeat to a centralied loghost.
+    """
+
+    nix_file_path = batou.component.Attribute(str, default="/etc/local/nixos/journalbeat.nix")
+    transport_name = batou.component.Attribute(str)
+    graylog_host = batou.component.Attribute(str)
+    graylog_port = batou.component.Attribute(int, default=12301)
+
+    def configure(self):
+
+        self += batou.lib.file.File(
+            self.nix_file_path,
+            content=pkg_resources.resource_string(
+                __name__, "resources/journalbeat.nix"))

--- a/src/batou_ext/journalbeat.py
+++ b/src/batou_ext/journalbeat.py
@@ -5,7 +5,7 @@ import pkg_resources
 
 class JournalBeatTransport(batou.component.Component):
 
-    """ A shortcut for sending logmessages via journalbeat to a centralied loghost.
+    """ A shortcut for sending logmessages via journalbeat to a centralised loghost.
     """
 
     nix_file_path = batou.component.Attribute(str, default="/etc/local/nixos/journalbeat.nix")

--- a/src/batou_ext/resources/journalbeat.nix
+++ b/src/batou_ext/resources/journalbeat.nix
@@ -1,0 +1,9 @@
+{ pkgs, lib, ... }:
+{
+  flyingcircus.journalbeat.logTargets = {
+    {{component.transport_name}} = {
+      host = "{{component.graylog_host}}";
+        port = {{component.graylog_port}};
+      };
+  };
+}


### PR DESCRIPTION
This MR adds an easy-to-use component to deploy a nix-configuration file for journalbeat to ship logs to a (project) centralized graylog server. 