### PR TITLE
(onto batou-2.3.x): pin github runner version to support python3.6, fix test failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: [ '3.6', '3.7', '3.8', '3.9' ]
 
 # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/src/batou_ext/tests/test_configure.py
+++ b/src/batou_ext/tests/test_configure.py
@@ -142,5 +142,10 @@ def test_prepare(root, mocker, component):
     elif component_name in {
             "batou_ext.fcio.DNSAliases", }:
         instance._call = lambda: None
+    elif component_name in {
+            "batou_ext.journalbeat.JournalBeatTransport", }:
+        instance.transport_name = "my_transport_name"
+        instance.graylog_host = "my_graylog_host"
+        instance.graylog_port = "my_graylog_port"
 
     instance.prepare(root)


### PR DESCRIPTION
See https://github.com/flyingcircusio/batou/pull/344 in batou and https://github.com/actions/setup-python/issues/544 in setup-python