### PR TITLE
Touch the build script before running it

### DIFF
--- a/src/batou_ext/run.py
+++ b/src/batou_ext/run.py
@@ -54,5 +54,6 @@ class Run(batou.component.Component):
         )
 
     def update(self):
+        self.touch(self.command_file.path)
         self.cmd(self.command_file.path)
         self.touch(f"{self.command_file.path}_stamp")


### PR DESCRIPTION
In some cases the Run component is triggered without the script itself being changed. If the command then fails after having completed successfully in previous deployments, it will not be triggered on subsequent runs because the stamp-file's modification date is newer than the script's modification date.

This pr introduces a `touch` on the command-file to ensure that if the component is triggered but the command itself fails, a subsequent deployments will trigger this Run component at the verify step and re-run the command until it completes successfully.

Related internal ticket: FC-30530