### PR TITLE
Explicitly set ownership to nginx for certs created by ssl Certificate()

### DIFF
--- a/src/batou_ext/ssl.py
+++ b/src/batou_ext/ssl.py
@@ -102,6 +102,8 @@ class Certificate(batou.component.Component):
     # You will need something like nrpehost or sensuchecks on the host
     enable_check = batou.component.Attribute("literal", default=True)
 
+    granted_user = batou.component.Attribute(str, default="nginx")
+
     _may_need_to_generate_certificates = False
 
     def configure(self):
@@ -248,6 +250,8 @@ openssl x509 -req -days 3650 \
     -out {{component.fullchain}}
 """
         )
+        self.cert_dir = os.path.join(self.workdir, self.domain)
+        self.cmd(f"setfacl -Rm u:{self.granted_user}:rX {self.cert_dir}")
         self.csr_file.close()
         del self.csr_file
 


### PR DESCRIPTION
When the service user places the cert, the cert is owned by it. If Nginx runs as root, this doesn't create any problems. But if Nginx runs as a separate user, it may be denied access to the cert.
This change sets the ownership of the created certs to `nginx`, to fix this problem.