### PR TITLE
[FC-31827] Also purge old mailhog service file

### DIFF
--- a/src/batou_ext/mail.py
+++ b/src/batou_ext/mail.py
@@ -140,6 +140,7 @@ class Mailhog(batou.component.Component):
         if self.purge_old_mailhog_configs:
             self += batou.lib.file.Purge("mailhog")
             self += batou.lib.file.Purge("mailhog_env")
+            self += batou.lib.file.Purge("/etc/local/systemd/mailhog.service")
             self += batou.lib.file.Purge("/etc/local/nginx/mailhog.conf")
             self += batou.lib.file.Purge("htdocs")
 


### PR DESCRIPTION
We switched from docker to nix for providing mailhog. Currently the old service files is not removed.