### PR TITLE
[fix] Fix OCI Version handling + passing entrypoint

### DIFF
--- a/src/batou_ext/oci.py
+++ b/src/batou_ext/oci.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 import re
+import shlex
 from typing import Optional
 
 import pkg_resources
@@ -31,6 +32,7 @@ class Container(Component):
 
     # specific options
     entrypoint: Optional[str] = None
+    docker_cmd: Optional[str] = None
     envfile: Optional[str] = None
     mounts: dict = {}
     ports: dict = {}
@@ -66,6 +68,9 @@ class Container(Component):
             # spec version overrides the argument provided or default version
             if spec_tag:
                 self.version = spec_tag
+            else:
+                # append version to image string when passed seperately
+                self.image = f"{self.image}:{self.version}"
         else:
             raise RuntimeError(
                 f"could not match the docker spec against the provided container image string: '{self.image}'"
@@ -86,6 +91,9 @@ class Container(Component):
 {% endfor %}""",
             )
             self.envfile = self._
+
+        if self.docker_cmd:
+            self._docker_cmd_list = shlex.split(self.docker_cmd)
 
         self += File(
             f"/etc/local/nixos/docker_{self.container_name}.nix",

--- a/src/batou_ext/resources/oci-template.nix
+++ b/src/batou_ext/resources/oci-template.nix
@@ -17,8 +17,12 @@
   virtualisation.oci-containers = {
     backend = "docker";
     containers."{{component.container_name}}" = {
-      # {% if component.entrypoint != None %}
+      # {% if component.entrypoint %}
       entrypoint = "{{component.entrypoint}}";
+      # {% endif %}
+
+      # {% if component.docker_cmd %}
+      cmd = [ {% for cmd in component._docker_cmd_list %} "{{cmd}}" {% endfor %} ];
       # {% endif %}
 
       # {% if component.registry_address %}

--- a/src/batou_ext/s3.py
+++ b/src/batou_ext/s3.py
@@ -29,7 +29,13 @@ from batou_ext.file import SymlinkAndCleanup
 
 
 class S3(batou.component.Component):
-    """Configuration for an S3 connection and its credentials."""
+    """Configuration for an S3 connection and its credentials.
+
+    Keyword arguments:
+    access_key_id     -- The S3 access key ID
+    secret_access_key -- The S3 secret access key
+    endpoint_url      -- The S3 enpoint's URL
+    """
 
     _required_params_ = {
         "access_key_id": "value",


### PR DESCRIPTION
this fixes version handling when doing so seperately from the image string as well as passing an entrypoint to the image. the nixos module requires the `entrypoint` to be a single file in PATH and all arguments for that file in `cmd`.

slightly related to this: we might need tight(er) unit tests to catch mistakes like these