### PR TITLE
s3.Bucket: Mention the bucket name that failed

### DIFF
--- a/src/batou_ext/s3.py
+++ b/src/batou_ext/s3.py
@@ -74,8 +74,12 @@ class Bucket(batou.component.Component):
         self.bucket = self.s3.client.Bucket(self.bucketname)
 
     def verify(self):
-        if not self.bucket.creation_date:
-            raise batou.UpdateNeeded()
+        try:
+            if not self.bucket.creation_date:
+                raise batou.UpdateNeeded()
+        except botocore.exceptions.ClientError as error:
+            self.log(f"Error while checking for bucket {self.bucketname}")
+            raise error
 
     def update(self):
         self.bucket.create()


### PR DESCRIPTION
This MR adds a hint on which bucket failed while processing the verify() from s3.Bucket(). This usually happens due to wrong access rights of a bucket (403) 