### PR TITLE
oci: restart the systemd unit on digest updates

### DIFF
--- a/src/batou_ext/oci.py
+++ b/src/batou_ext/oci.py
@@ -153,3 +153,6 @@ class Container(Component):
 
         if local_digest != remote_digest:
             raise UpdateNeeded()
+
+    def update(self):
+        self.cmd(f"sudo systemctl restart docker-{self.container_name}")


### PR DESCRIPTION
For deployments where the container's version stays the same but the digest changes a service restart needs to be triggered in order to pull the newest container of the same tag with `--pull=always`