### PR TITLE
[FC-32491] get rid of userenv

### DIFF
--- a/CHANGES.d/20231124_103923_ph_FC_32491_rid_of_userenv.md
+++ b/CHANGES.d/20231124_103923_ph_FC_32491_rid_of_userenv.md
@@ -1,0 +1,1 @@
+* Rework the UserEnv module to not rely on fragile `nix-env` invocations

--- a/src/batou_ext/resources/userenv.nix
+++ b/src/batou_ext/resources/userenv.nix
@@ -1,27 +1,14 @@
-let
-  # see https://nixos.org/channels/
-  nixpkgs = fetchTarball {{component.channel}};
-
-in
-{ pkgs ? import nixpkgs { } }:
-
-with pkgs;
-let
-
-  shellInit = writeText "shellInit"''
-
-    {{component.shellInit.replace('\n', '\n    ').strip()}}
-  '';
-
+{ pkgs, ... }: let
   {{component.let_extra}}
 
-in buildEnv {
-    name = "{{ '{{' }}component.nix_env_name{{ '}}' }}";
-    paths = [
-      (runCommand "profile" { } "install -D ${shellInit} $out/etc/profile.d/{{component.profile_name}}.sh")
-      {%- for name in component.packages %}
-      {{name}}
-      {%- endfor %}
-    ];
-    extraOutputsToInstall = [ "bin" "dev" "lib" "man" "out" ];
+in {
+  users.users."{{component.environment.service_user}}".packages = with pkgs; [
+    # {%- for name in component.packages %}
+    {{name}}
+    # {%- endfor %}
+  ];
+
+  environment.shellInit = ''
+    {{component.shellInit.replace('\n', '\n    ').strip()}}
+  '';
 }


### PR DESCRIPTION
The old userenv module relied on nix envs, which are prone to breakage on system upgrades. the new approach will function the same, but eliminate the possibility of breakage while also being more discoverable in the `/etc/local/nixos` directory

tested via a custom test deployment