### PR TITLE
[FC-34648] reduce mailhog log output

### DIFF
--- a/CHANGES.d/20231205_145736_ph_FC_34648_reduce_mailhog_logoutput.md
+++ b/CHANGES.d/20231205_145736_ph_FC_34648_reduce_mailhog_logoutput.md
@@ -1,0 +1,2 @@
+- add an option to move mailhog log output (`stdout` + `stderr`) to a different namespace, e.g. "mailhog". see systemd.exec(5) for more information
+- add an option to disable `stdout` logging for the mailhog service

--- a/src/batou_ext/mail.py
+++ b/src/batou_ext/mail.py
@@ -126,6 +126,9 @@ class Mailhog(batou.component.Component):
     http_auth_enable = batou.component.Attribute("literal", default=False)
     http_basic_auth = None
 
+    systemd_namespace = batou.component.Attribute(str, default="")
+    disable_stdout = batou.component.Attribute("literal", default=False)
+
     # Either memory or maildir
     # mongodb is not yet supported
     storage_engine = batou.component.Attribute(str, default="memory")

--- a/src/batou_ext/resources/mailhog/mailhog.nix
+++ b/src/batou_ext/resources/mailhog/mailhog.nix
@@ -1,20 +1,27 @@
-{ pkgs, lib, ... }:
-{
+{ lib, ... }: {
   services.mailhog = {
     enable = true;
-    apiPort = {{component.apiport}};
-    smtpPort = {{component.mailport}};
-    uiPort = {{component.uiport}};
+    apiPort = lib.toInt "{{component.apiport}}";
+    smtpPort = lib.toInt "{{component.mailport}}";
+    uiPort = lib.toInt "{{component.uiport}}";
     storage = "{{component.storage_engine}}";
   };
+
+  # {% if component.systemd_namespace != "" %}
+  systemd.services.mailhog.serviceConfig.LogNamespace = "{{component.systemd_namespace}}";
+  # {% endif %}
+
+  # {% if component.disable_stdout %}
+  systemd.services.mailhog.serviceConfig.StandardOutput = "null";
+  # {% endif %}
 
   flyingcircus.services.nginx.virtualHosts = {
     "{{component.public_name}}" = {
       forceSSL = true;
       enableACME = true;
-      {% if component.http_auth_enable %}
+      # {% if component.http_auth_enable %}
       basicAuthFile = "{{component.http_auth.path}}";
-      {% endif %}
+      # {% endif %}
       locations = {
         "/" = {
           proxyPass = "http://localhost:{{component.uiport}}";


### PR DESCRIPTION
moving the entire mailhog log output to a different namespace considerably reduces clutter while retaining debuggability

you can inspect the logs using `journalctl --namespace=mailhog`