### PR TITLE
[FC-34644] Improve error message for PurgePackage

### DIFF
--- a/CHANGES.d/20231206_155338_ph_FC_34644_improve_nix_purge_error.md
+++ b/CHANGES.d/20231206_155338_ph_FC_34644_improve_nix_purge_error.md
@@ -1,0 +1,1 @@
+- Improve output handling for the `PurgePackage` component. Will not appear like a fatal error in logs anymore when the package has been purged already or is not installed for another reason

--- a/src/batou_ext/nix.py
+++ b/src/batou_ext/nix.py
@@ -72,10 +72,16 @@ class PurgePackage(batou.component.Component):
 
     def verify(self):
         try:
-            self.cmd("nix-env --query {{component.package}}")
+            self.cmd(f"nix-env --query {self.package}")
             raise batou.UpdateNeeded()
         except batou.utils.CmdExecutionError as e:
-            e.report()
+            if e.stderr.endswith("matches no derivations"):
+                batou.output.annotate(
+                    f"Could not find package to purge: {self.package}",
+                    yellow=True,
+                )
+            else:
+                e.report()
 
     def update(self):
         self.cmd("nix-env --uninstall {{component.package}}")


### PR DESCRIPTION
Improve the output handling for PurgePackage. In cases where the Package has been purged already the output should not appear to be a fatal error in the deployment (red letters, big section dedicated to it)