### PR TITLE
feat: versions.py: allow multiple environments per branch

### DIFF
--- a/CHANGES.d/20240201_170638_ph_multiple_environments_per_branch.md
+++ b/CHANGES.d/20240201_170638_ph_multiple_environments_per_branch.md
@@ -1,0 +1,1 @@
+- Change the behaviour of the batou_ext.versions updater to allow environments to share a branch

--- a/src/batou_ext/versions.py
+++ b/src/batou_ext/versions.py
@@ -47,18 +47,16 @@ class Updater:
             self._environment.load()
         return self._environment
 
-    def set_environment_from_branch(self, branch):
+    def update_from_branch(self, branch: str):
         envs = sorted(os.listdir(os.path.join(self.basedir, "environments")))
         for env_name in envs:
             env = batou.environment.Environment(env_name)
             env.load()
             if env.branch == branch:
-                if self.environment_name:
-                    raise ValueError(
-                        f"Branch {branch} is used in multiple enviornments, "
-                        "cannot auto-update."
-                    )
+                print(f"Updating environment: {env_name}")
                 self.environment_name = env_name
+                self.set_versions()
+
         if not self.environment_name:
             raise ValueError(
                 f"Branch {branch} is not used in any environment, "
@@ -157,11 +155,12 @@ def main():
 
     if args.environment:
         update.environment_name = args.environment
+        update.set_versions()
     elif args.branch:
-        update.set_environment_from_branch(args.branch)
+        update.update_from_branch(args.branch)
     else:
         update.interactive()
-    update.set_versions()
+        update.set_versions()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
some deployments have a multitude of environments that might share the same branch.
previously, this would break our semi-established gitlab pipeline's version update step