### PR TITLE
[FC-35973] systemd timers non-persistent by default

### DIFF
--- a/CHANGES.d/20240206_113523_ph.md
+++ b/CHANGES.d/20240206_113523_ph.md
@@ -1,0 +1,4 @@
+- systemd timers: add an option to enable persistence
+  breaking change: systemd timers are now non-persistent by default.
+  The previous default behaviour was a problem for cronjobs that should
+  not be started immediately following a deployment.


### PR DESCRIPTION
Systemd Timers were persistent by default previously. Since that implies a trigger on first activation, this is unwanted behaviour for Jobs that interact with the outside world, e.g. sending out emails.

The old behaviour can be enabled optionally.
Looking over some uses of this Component in our deployments, I did not find any that rely on the old behaviour or ones that would not work with the new default.