### PR TITLE
improve detection of versions.ini

### DIFF
--- a/CHANGES.d/20240408_101449_ph_versions_ini_fallback.md
+++ b/CHANGES.d/20240408_101449_ph_versions_ini_fallback.md
@@ -1,0 +1,7 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+- improve dectection of a versions file for versions updates

--- a/src/batou_ext/versions.py
+++ b/src/batou_ext/versions.py
@@ -65,7 +65,14 @@ class Updater:
 
     @property
     def versions_ini(self):
-        return self.environment.overrides["settings"]["versions_ini"]
+        if "versions_ini" in self.environment.overrides["settings"]:
+            return self.environment.overrides["settings"]["versions_ini"]
+        elif os.path.exists("versions.ini"):
+            return "versions.ini"
+        else:
+            raise ValueError(
+                "No versions.ini specified in the environment file (via `settings.versions_ini`) and the file `versions.ini` does not exist in the git root, cannot proceed"
+            )
 
     def interactive(self):
         envs = os.listdir(os.path.join(self.basedir, "environments"))


### PR DESCRIPTION
Since versions.ini is the default in most deployments, the version module should attempt to read the current versions from there instead of erroring with a cryptic error message.

Previously, a key error would be displayed when attempting to read the versions_ini from the settings part of the environment overrides without it being specified explicitly.