### PR TITLE
[oci] trigger container restarts on env file changes

### DIFF
--- a/CHANGES.d/20240412_113216_ph_oci_envfile_subcomponent_fix.md
+++ b/CHANGES.d/20240412_113216_ph_oci_envfile_subcomponent_fix.md
@@ -1,0 +1,6 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+- fix the oci.Container verify method not throwing an updaterequired on changes to the docker container's environment file

--- a/src/batou_ext/oci.py
+++ b/src/batou_ext/oci.py
@@ -67,7 +67,7 @@ class Container(Component):
     # specific options
     entrypoint: Optional[str] = None
     docker_cmd: Optional[str] = None
-    envfile: Optional[str] = None
+    envfile: Optional[File] = None
     mounts: dict = {}
     ports: dict = {}
     env: dict = {}
@@ -125,6 +125,9 @@ class Container(Component):
         )
 
     def verify(self):
+        self.assert_no_changes()
+        self.envfile.assert_no_changes()
+
         if self.registry_address:
             logintxt, _ = self.cmd(
                 self.expand(


### PR DESCRIPTION
the oci.container component now triggers an update if a provided env-file component changes.
This update will lead to the container service being restarted correctly after a change to the envfile's content