### PR TITLE
[FC-37087] systemd timers non-persistent by default

### DIFF
--- a/CHANGES.d/20240206_113523_ph.md
+++ b/CHANGES.d/20240206_113523_ph.md
@@ -1,0 +1,4 @@
+- systemd timers: add an option to enable persistence
+  breaking change: systemd timers are now non-persistent by default.
+  The previous default behaviour was a problem for cronjobs that should
+  not be started immediately following a reboot / downtime


### PR DESCRIPTION
This pr is based on !148 but addresses a different problem. Systemd timers should be non-persistent by default so as to not trigger immediately when booting after longer downtimes, which in most cases is unintended behaviour.

There is an option to re-enable this behaviour per timer.