### PR TITLE
nixos.NixOSModule: Mark generated context file as sensitive data

### DIFF
--- a/CHANGES.d/20240502_102711_fl_167_nixosmodul_context_sensible_data.md
+++ b/CHANGES.d/20240502_102711_fl_167_nixosmodul_context_sensible_data.md
@@ -1,0 +1,1 @@
+- nixos.NixOSModule: Mark generated context file as sensitive (Fixes #167)

--- a/src/batou_ext/nixos.py
+++ b/src/batou_ext/nixos.py
@@ -42,6 +42,7 @@ class NixOSModuleContext(Component):
             f"{self.prefix}_generated_context.nix",
             content=context,
             format_nix_code=True,
+            sensitive_data=True,
         )
 
 


### PR DESCRIPTION
This file might contain secrets and we should ensure aside from batou's core detection to don't show it inside CI logs.

Fixes #167