### PR TITLE
[FC-38040] python.FixELFRunPath: use all directories inside env_directory for rpath

### DIFF
--- a/CHANGES.d/20240514_152634_mb_FC_38040_rpath_recursive.md
+++ b/CHANGES.d/20240514_152634_mb_FC_38040_rpath_recursive.md
@@ -1,0 +1,1 @@
+* `batou_ext.python.FixELFRunPath`: search not only `env_directory`, but also its subdirs for C libraries needed by the libraries to patch.


### PR DESCRIPTION
FC-38040

E.g. mariadb puts its libraries into `$out/lib/mariadb` rather than `$out/lib` which would result in MySQLdb not finding the relevant library.

Please note that `--shrink-rpath` makes sure that only the subdirectories are added to DT_RPATH that are truly needed according to DT_NEEDED.