### PR TITLE
Fix `PurgePackage` raising error when package is not found.

### DIFF
--- a/CHANGES.d/20240515_113454_cz_patch_3.md
+++ b/CHANGES.d/20240515_113454_cz_patch_3.md
@@ -1,0 +1,1 @@
+- Fix `PurgePackage` raising error when package is not found.

--- a/src/batou_ext/nix.py
+++ b/src/batou_ext/nix.py
@@ -95,7 +95,7 @@ class PurgePackage(batou.component.Component):
             self.cmd(f"nix-env --query {self.package}")
             raise batou.UpdateNeeded()
         except batou.utils.CmdExecutionError as e:
-            if e.stderr.endswith("matches no derivations"):
+            if e.stderr.strip().endswith("matches no derivations"):
                 batou.output.annotate(
                     f"Could not find package to purge: {self.package}",
                     yellow=True,


### PR DESCRIPTION
replaces #172 by @sweh 


Current behavior:

```
110d05e4281: Scheduling component crontab ...
110d05e4281 > Filebeat > PurgePackage('filebeat')
ERROR: nix-env --query filebeat
    Return code: 1
STDOUT

STDERR
error: selector 'filebeat' matches no derivations

110d05e4281 > CronTab > InstallCrontab
```

Expected behaviour (achieved by this fix):

```
110d05e4281: Scheduling component crontab ...
110d05e4281 > Filebeat > PurgePackage('filebeat')
Could not find package to purge: filebeat
110d05e4281 > CronTab > InstallCrontab
```