### PR TITLE
[FC-38258] persist async cleanups

### DIFF
--- a/src/batou_ext/file.py
+++ b/src/batou_ext/file.py
@@ -119,12 +119,14 @@ class SymlinkAndCleanup(batou.component.Component):
                 ]
                 extra_args = self.systemd_extra_args or []
                 cmd = [
+                    "nohup",
                     "systemd-run",
                     "--unit",
                     f"batou-cleanup-{self.prefix}",
                     "--user",
                     *extra_args,
                     *rm_cmd,
+                    "&",
                 ]
                 batou.output.annotate(f"Removing: {candidates}")
                 batou.output.annotate(f"    {cmd}")


### PR DESCRIPTION
previously, the async cleanup was terminated when the deployment's ssh session was exited

invocating the process via nohup fixes that problem by persisting the systemd-run process beyond the duration of the ssh session