### PR TITLE
[FC-38393] Fix container verification not triggering correctly

### DIFF
--- a/CHANGES.d/20240604_101830_ph_fix_container_restart_when_newer_version_locally_available.md
+++ b/CHANGES.d/20240604_101830_ph_fix_container_restart_when_newer_version_locally_available.md
@@ -1,0 +1,1 @@
+- fix a bug where containers were not restarted properly even though their image digest was out of sync after the remote tag has been updated

--- a/CHANGES.d/20240604_102506_ph_fix_container_restart_when_newer_version_locally_available.md
+++ b/CHANGES.d/20240604_102506_ph_fix_container_restart_when_newer_version_locally_available.md
@@ -1,0 +1,1 @@
+- fix a typo in the oci container component's verify method

--- a/src/batou_ext/oci.py
+++ b/src/batou_ext/oci.py
@@ -1,7 +1,7 @@
 import os
 import shlex
 from textwrap import dedent
-from typing import Optional
+from typing import Dict, Optional
 
 import batou
 from batou import UpdateNeeded
@@ -86,7 +86,7 @@ class Container(Component):
     # cache spanning multiple components deploying the same container
     # the values are bools indicating whether or not containers with
     # this specific digest are up to date
-    _remote_manifest_cache: dict[str, bool] = {}
+    _remote_manifest_cache: Dict[str, bool] = {}
 
     def configure(self):
         if (


### PR DESCRIPTION
This PR fixes a case where the update is not triggered even though the running and locally available running and the locally available image are different, because the digest has been has been added to the cache.

I also restructured the code a bit. By using early returns and thereby removing deeply nested structures, the control flow becomes much easier to follow

edit: has to be tested, please do not merge yet