### PR TITLE
[FC-39629] fix the versions update

### DIFF
--- a/CHANGES.d/20240711_144012_ph_FC_39629_fix_versions_update.md
+++ b/CHANGES.d/20240711_144012_ph_FC_39629_fix_versions_update.md
@@ -1,0 +1,1 @@
+- Fix a bug in the version update script where multiple environments sharing the same branch would not be updated correctly

--- a/src/batou_ext/versions.py
+++ b/src/batou_ext/versions.py
@@ -27,108 +27,103 @@ def get_git_version_completer(url):
     return ThreadedCompleter(FuzzyWordCompleter(get_words))
 
 
-class Updater:
-    """Version update, interactive or automatic."""
-
-    environment_name: str = None
-    _environment = None
-    _target_versions = None
-
-    def __init__(self, basedir):
-        self.basedir = basedir
-
-    @property
-    def environment(self):
-        if self._environment is None:
-            assert self.environment_name
-            self._environment = batou.environment.Environment(
-                self.environment_name
-            )
-            self._environment.load()
-        return self._environment
-
-    def update_from_branch(self, branch: str):
-        envs = sorted(os.listdir(os.path.join(self.basedir, "environments")))
-        for env_name in envs:
-            env = batou.environment.Environment(env_name)
-            env.load()
-            if env.branch == branch:
-                print(f"Updating environment: {env_name}")
-                self.environment_name = env_name
-                self.set_versions()
-
-        if not self.environment_name:
-            raise ValueError(
-                f"Branch {branch} is not used in any environment, "
-                "cannot auto-upate."
-            )
-
-    @property
-    def versions_ini(self):
-        if "versions_ini" in self.environment.overrides["settings"]:
-            return self.environment.overrides["settings"]["versions_ini"]
-        elif os.path.exists("versions.ini"):
-            return "versions.ini"
-        else:
-            raise ValueError(
-                "No versions.ini specified in the environment file (via `settings.versions_ini`) and the file `versions.ini` does not exist in the git root, cannot proceed"
-            )
-
-    def interactive(self):
-        envs = os.listdir(os.path.join(self.basedir, "environments"))
-        envs.sort()
-        self.environment_name = inquirer.select(
-            message="Select environment to update",
-            choices=envs,
-        ).execute()
-
-        versions = configparser.ConfigParser()
-        versions.read(os.path.join(self.basedir, self.versions_ini))
-        components = versions.sections()
-        selected_components = inquirer.select(
-            message="Select components to update (Space to select, Ctrl-A for all):",
-            choices=components,
-            multiselect=True,
-        ).execute()
-
-        self._target_versions = {}
-        for c in selected_components:
-            try:
-                default = versions.get(c, "default")
-            except configparser.NoOptionError:
-                default = ""
-
-            git_url = versions[c].get("url")
-            if git_url:
-                git_completer = get_git_version_completer(git_url)
-            else:
-                git_completer = None
-            new_version = inquirer.text(
-                message=f"Update {c} to:",
-                default=default,
-                completer=git_completer,
-            ).execute()
-
-            self._target_versions[c] = new_version
-
-    def set_versions(self):
-        if self._target_versions is None:
-            self._target_versions = {}
-            versions = configparser.ConfigParser()
-            versions.read(os.path.join(self.basedir, self.versions_ini))
-            for section in versions.sections():
-                try:
-                    self._target_versions[section] = versions.get(
-                        section, "default"
-                    )
-                except configparser.NoOptionError:
-                    pass
-
-        updater = VersionsUpdater(
-            self.versions_ini, json.dumps(self._target_versions)
+def find_versions_ini(environment: batou.environment.Environment):
+    if "versions_ini" in environment.overrides["settings"]:
+        return environment.overrides["settings"]["versions_ini"]
+    elif os.path.exists("versions.ini"):
+        return "versions.ini"
+    else:
+        raise ValueError(
+            "No versions.ini specified in the environment file (via `settings.versions_ini`) and the file `versions.ini` does not exist in the git root, cannot proceed"
         )
-        updater()
-        subprocess.run(["git", "-P", "diff", self.versions_ini])
+
+
+def select_versions_interactive(basedir: str) -> dict:
+    envs = os.listdir(os.path.join(basedir, "environments"))
+    envs.sort()
+    environment_name = inquirer.select(
+        message="Select environment to update",
+        choices=envs,
+    ).execute()
+
+    environment = batou.environment.Environment(environment_name)
+    environment.load()
+
+    versions = configparser.ConfigParser()
+    versions_ini = find_versions_ini(environment)
+    versions.read(os.path.join(basedir, versions_ini))
+
+    components = versions.sections()
+    selected_components = inquirer.select(
+        message="Select components to update (Space to select, Ctrl-A for all):",
+        choices=components,
+        multiselect=True,
+    ).execute()
+
+    interative_versions = {}
+    for c in selected_components:
+        try:
+            default = versions.get(c, "default")
+        except configparser.NoOptionError:
+            default = ""
+
+        git_url = versions[c].get("url")
+        if git_url:
+            git_completer = get_git_version_completer(git_url)
+        else:
+            git_completer = None
+        new_version = inquirer.text(
+            message=f"Update {c} to:",
+            default=default,
+            completer=git_completer,
+        ).execute()
+
+        interative_versions[c] = new_version
+    return interative_versions
+
+
+def get_current_versions(
+    basedir: str, environment: batou.environment.Environment
+):
+    versions = configparser.ConfigParser()
+    versions_ini = find_versions_ini(environment)
+    versions.read(os.path.join(basedir, versions_ini))
+
+    target_versions = {}
+    for section in versions.sections():
+        try:
+            target_versions[section] = versions.get(section, "default")
+        except configparser.NoOptionError:
+            pass
+    return target_versions
+
+
+def update_from_branch(basedir: str, branch: str):
+    envs = sorted(os.listdir(os.path.join(basedir, "environments")))
+    for env_name in envs:
+        environment = batou.environment.Environment(env_name)
+        environment.load()
+
+        if environment.branch != branch:
+            continue
+
+        print(f"Updating environment: {env_name}")
+        current_versions = get_current_versions(basedir, environment)
+        versions_ini = find_versions_ini(environment)
+        set_versions(versions_ini, current_versions)
+
+
+def update_single(basedir: str, environment_name: str):
+    environment = batou.environment.Environment(environment_name)
+    versions_ini = find_versions_ini(environment)
+    current_versions = get_current_versions(basedir, environment)
+    set_versions(versions_ini, current_versions)
+
+
+def set_versions(versions_ini: str, target_versions: dict):
+    updater = VersionsUpdater(versions_ini, json.dumps(target_versions))
+    updater()
+    subprocess.run(["git", "-P", "diff", versions_ini])
 
 
 def main():
@@ -158,16 +153,13 @@ def main():
 
     args = parser.parse_args()
 
-    update = Updater(args.basedir)
-
     if args.environment:
-        update.environment_name = args.environment
-        update.set_versions()
+        update_single(basedir, args.environment)
     elif args.branch:
-        update.update_from_branch(args.branch)
+        update_from_branch(basedir, args.branch)
     else:
-        update.interactive()
-        update.set_versions()
+        target_versions = select_versions_interactive()
+        set_versions(target_versions)
 
 
 if __name__ == "__main__":

--- a/src/batou_ext/versions.py
+++ b/src/batou_ext/versions.py
@@ -99,7 +99,9 @@ def get_current_versions(
 
 
 def update_from_branch(basedir: str, branch: str):
+    branch_is_used = False
     envs = sorted(os.listdir(os.path.join(basedir, "environments")))
+
     for env_name in envs:
         environment = batou.environment.Environment(env_name)
         environment.load()
@@ -107,10 +109,17 @@ def update_from_branch(basedir: str, branch: str):
         if environment.branch != branch:
             continue
 
+        branch_is_used = True
+
         print(f"Updating environment: {env_name}")
         current_versions = get_current_versions(basedir, environment)
         versions_ini = find_versions_ini(environment)
         set_versions(versions_ini, current_versions)
+
+    if not branch_is_used:
+        raise ValueError(
+            f"Branch {branch} is not used in any environment, cannot auto-upate."
+        )
 
 
 def update_single(basedir: str, environment_name: str):


### PR DESCRIPTION
the versions update would only update the first environment which breaks branch-based automatic updates when multiple environments use the same branc

this pr also splits the updater class into multiple reusable single-use functions to better compose the implemented functionality