### PR TITLE
[FC-40344] load the environment when updating it's requirements

### DIFF
--- a/src/batou_ext/versions.py
+++ b/src/batou_ext/versions.py
@@ -124,6 +124,7 @@ def update_from_branch(basedir: str, branch: str):
 
 def update_single(basedir: str, environment_name: str):
     environment = batou.environment.Environment(environment_name)
+    environment.load()
     versions_ini = find_versions_ini(environment)
     current_versions = get_current_versions(basedir, environment)
     set_versions(versions_ini, current_versions)


### PR DESCRIPTION
the versions update fails to find the settings override section when the environment has not been loaded before 