### PR TITLE
[FC-40064] skip serializing instances

### DIFF
--- a/CHANGES.d/20240829_112623_ph_FC_40064_skip_serializing_instances.md
+++ b/CHANGES.d/20240829_112623_ph_FC_40064_skip_serializing_instances.md
@@ -1,0 +1,1 @@
+- fix a mysterious regression that cause a test to fail

--- a/src/batou_ext/nix.py
+++ b/src/batou_ext/nix.py
@@ -630,7 +630,7 @@ def component_to_nix(component: Component):
             pass
         elif inspect.ismethod(value) or inspect.isgenerator(value):
             pass
-        elif name in ("sub_components", "changed"):
+        elif name in ("sub_components", "changed", "instances"):
             pass
         elif isinstance(value, NixOSModuleContext):
             pass


### PR DESCRIPTION
ci was broken for the nixos module context because it tried to serialize all instances of the test component, one of which did not have a loaded environment which is why it was missing the deployment_base attribute