### PR TITLE
[FC-40616] Fix tests

### DIFF
--- a/src/batou_ext/http.py
+++ b/src/batou_ext/http.py
@@ -21,7 +21,7 @@ class HTTPBasicAuth(batou.component.Component):
         from batou_ext.http import HTTPBasicAuth
 
         self += batou_ext.http.HTTPBasicAuth(
-            "myauth",
+            env_name="myauth",
             username="joe",
             password="secret",
             basic_auth_string="joe:$apr1$Ma0Fc6pW$Kl5dV4ecBXH12gDieRHVq.")

--- a/src/batou_ext/tests/test_configure.py
+++ b/src/batou_ext/tests/test_configure.py
@@ -172,4 +172,8 @@ def test_prepare(root, mocker, component, tmpdir):
         instance.script = "/srv/s-myuser/start-application.sh"
         instance.watchdog_script_path = "/srv/s-myuser/watchdog-wrapper.py"
         instance.healthcheck_url = "https://example.com"
+    elif component_name == "batou_ext.mail.Mailpit":
+        batou_ext.http.HTTPBasicAuth(
+            **batou_ext.http.HTTPBasicAuth._required_params_
+        ).prepare(root)
     instance.prepare(root)


### PR DESCRIPTION


Mailpit always expects a basic auth component, so we add one to the deployment.

Alsio noticed that `env_name` isn't a namevar for `HTTPBasicAuth`, so fixed up the docstring to reflect that.