### PR TITLE
redis.Redis: Allow to set provide name for redis component

### DIFF
--- a/CHANGES.d/20240904_090115_fl.md
+++ b/CHANGES.d/20240904_090115_fl.md
@@ -1,0 +1,1 @@
+- redis.Redis: Allow to set provide name

--- a/src/batou_ext/redis.py
+++ b/src/batou_ext/redis.py
@@ -25,9 +25,11 @@ class Redis(batou.component.Component):
     cleanup = batou.component.Attribute("literal", default=False)
     cleanup_command = batou.component.Attribute(str, default="FLUSHDB")
 
+    provide_as = batou.component.Attribute(str, default="redis")
+
     def configure(self):
         assert self.password
-        self.provide("redis", self)
+        self.provide(self.provide_as, self)
 
         self.address = batou.utils.Address(self.host.fqdn, self.port)
         self += batou.lib.file.File(


### PR DESCRIPTION
When using multiple instances of Redis – e.g. via inheritance – it makes sense to override the value, the Redis is providing itself. 