### PR TITLE
[FC-40636] file: fix tmpfiles-clean config

### DIFF
--- a/CHANGES.d/20240905_115653_mb_FC_40636_systemd_settings.md
+++ b/CHANGES.d/20240905_115653_mb_FC_40636_systemd_settings.md
@@ -1,0 +1,6 @@
+* The `SymlinkAndCleanup` internally uses the `DeploymentTrash` component internally which
+  deletes old code using `systemd-tmpfiles` and throttles the operation with `IOReadIOPSMax`
+  and `IOWriteIOPSMax`.
+
+  This didn't have any effect before because these settings were wrongly placed in `[Unit]`
+  instead of `[Service]`.

--- a/src/batou_ext/file.py
+++ b/src/batou_ext/file.py
@@ -178,7 +178,7 @@ class DeploymentTrash(batou.component.Component):
                 "d {{component.trashdir}} 0755 - - 1h -"
               ];
 
-              systemd.services."systemd-tmpfiles-clean".unitConfig = {
+              systemd.services."systemd-tmpfiles-clean".serviceConfig = {
                 IOReadIOPSMax="{{component.trashdir}} {{component.read_iops_limit}}";
                 IOWriteIOPSMax="{{component.trashdir}} {{component.write_iops_limit}}";
               };


### PR DESCRIPTION


IOReadIOPSMax/IOWriteIOPSMax are part of the `[Service]` section.