### PR TITLE
[FC-40974] SingleUntar: touch `self.target` on update

### DIFF
--- a/src/batou_ext/archive.py
+++ b/src/batou_ext/archive.py
@@ -58,6 +58,7 @@ class SingleUntar(batou.lib.archive.Untar):
     def update(self):
         if not self._only_marker_cleanup:
             super().update()
+            self.touch(self.target)
             self.touch(self._finish_marker)
 
         for old_marker in self._markers_to_unlink:


### PR DESCRIPTION
Consider the following use-case:

* `self.target` is an existing Git checkout at `/mnt/nfs/shared/{project_code}`
* prebuilt assets are unpacked into a given directory in `self.target` (the exact directory is encoded in the archive, so `self.target` is exactly the git checkout).

Now, using `SingleUntar` isn't convergent in this case because it tries to unpack the assets on each deploy: this is because the mtime of `self.target` isn't affected by the unpack since the files are unpacked into a directory inside `self.target`.

The `self.touch` solves the issue by updating the mtime of the target.

This is not expected to affect the "traditional" use-case of `SingleUntar` where a new unpack _creates_ a new directory called `self.target`.