### PR TITLE
[FC-41616] FixELFRunPath: shrink & add-rpath in a single operation

### DIFF
--- a/CHANGES.d/20241115_092716_mb_FC_41616_patchelf_size_issue.md
+++ b/CHANGES.d/20241115_092716_mb_FC_41616_patchelf_size_issue.md
@@ -1,0 +1,7 @@
+- The component `batou_ext.python.FixELFRunPath` now uses a patched version of patchelf to make sure that the
+  dynamic libraries don't get larger per deploy.
+
+  When a certain threshold is exceeded, Python will fail to import these.
+
+  If the component got regularly executed in deployments, you may want to consider recreating
+  the virtualenv once.


### PR DESCRIPTION
The core issue is that each `--add-rpath` makes the ELF header a little larger whereas `--shrink-rpath` doesn't remove the extra space allocated by `--add-rpath`. If this isn't done in a `nix-build` where the increased space is probably neglible, but in an imperatively managed virtualenv (which is the case here), then the dynamic libraries will blow up and at some point fail with a segfault when Python tries to open those[1].

This change basically applies a `patchelf(1)` patch that provides a flag `--add-rpath-and-shrink` which performs both operations at once so that there's no additional space allocated in the first place.

[1] Interestingly, I failed to trigger the exact error with a `dlopen(2)`
    call in a C program.