### PR TITLE
[FC-41962] jenkins: always resolve tags to rev of the commit that got tagged

### DIFF
--- a/CHANGES.d/20241121_122503_mb_FC_41962_tag_resolution.md
+++ b/CHANGES.d/20241121_122503_mb_FC_41962_tag_resolution.md
@@ -1,0 +1,3 @@
+- Correctness fix for `jenkins set-version`: if a tag is resolved, make sure it's _always_
+  resolved to the rev of the tagged commit (instead of the tag's rev) or fail hard to avoid
+  incorrect revs.


### PR DESCRIPTION
FC-41962
Closes https://github.com/flyingcircusio/batou_ext/issues/200

Some tags have a their own revision which is not the revision of the
commit that got tagged. This happens e.g. for tags with messages or
signatures.

Previously, we tried to resolve the latter (that's what the `^{}`-syntax
is for) and if this "fails" (i.e. stdout is empty, but the exit-code is
zero), we made a fallback to `git ls-remote url tag`.

This however had the unintended side-effect that an annotated tag was
resolved to the tag's revision (fallback) if the first call failed due
to a transient error like a DNS outage. In some cases this broke
subsequent deployment steps if the S3 URL for frontend artifacts
contains the commit revision (and not the tag's revision).

This patch explicitly checks for errors in `git ls-remote` (if something
isn't found, we get zero as exit-code and no stdout) and fail hard.
Also, the `ls-remote` without the `^{}` is done first. This avoids a
second `ls-remote` call for refs that aren't tags.