### PR TITLE
batou_ext.oci: Add support for `podman`

### DIFF
--- a/CHANGES.d/20241129_131748_mb_FC_37959_podman.md
+++ b/CHANGES.d/20241129_131748_mb_FC_37959_podman.md
@@ -1,0 +1,9 @@
+- `batou_ext.oci.Container`: allow to use `podman` as backend instead of `docker`.
+  This also enables the following features:
+
+  * Rootless containers: by setting the `user` option to a different user. By default,
+    the service user of the deployment is used.
+
+  * Only mark services as `active` if the container is up. This requires that the
+    container has a healthcheck. Alternatively, a healthcheck can be configured
+    with the health_cmd attribute.

--- a/src/batou_ext/http.py
+++ b/src/batou_ext/http.py
@@ -61,7 +61,6 @@ class HTTPBasicAuth(batou.component.Component):
         self.path = self._.path
 
 
-@batou_ext.nix.rebuild
 class HTTPServiceWatchdog(batou.component.Component):
     """
     Adds a "watchdog" on top of a systemd service that checks within a given interval
@@ -209,6 +208,8 @@ class HTTPServiceWatchdog(batou.component.Component):
     start_timeout = batou.component.Attribute(int, default=64)
     watchdog_interval = batou.component.Attribute(int, default=64)
 
+    rebuild = batou.component.Attribute("literal", default=True)
+
     def configure(self):
         if self.predefined_service and self.script is not None:
             raise ValueError(
@@ -225,6 +226,9 @@ class HTTPServiceWatchdog(batou.component.Component):
                 __name__, "resources/http-watchdog.nix"
             ),
         )
+
+        if self.rebuild:
+            self += batou_ext.nix.Rebuild()
 
 
 class HTTPWatchdogScript(batou.component.Component):

--- a/src/batou_ext/resources/oci-template.nix
+++ b/src/batou_ext/resources/oci-template.nix
@@ -2,13 +2,13 @@
 {
   # {% if component.monitor %}
   flyingcircus = {
-    services.sensu-client.checks."docker-{{component.container_name}}" = {
+    services.sensu-client.checks."{{ component.backend }}-{{component.container_name}}" = {
       notification = "Status of container {{component.container_name}}";
       command = ''
-        if $(systemctl is-active --quiet docker-{{component.container_name}}); then
-          echo "docker container {{component.container_name}} is ok"
+        if $(systemctl is-active --quiet {{ component.backend }}-{{component.container_name}}); then
+          echo "{{ component.backend }} container {{component.container_name}} is ok"
         else
-          echo "docker container {{component.container_name}} is inactive"
+          echo "{{ component.backend }} container {{component.container_name}} is inactive"
           exit 2
         fi
       '';
@@ -17,7 +17,6 @@
   # {% endif %}
 
   virtualisation.oci-containers = {
-    backend = "docker";
     containers."{{component.container_name}}" = {
       # {% if component.entrypoint %}
       entrypoint = "{{component.entrypoint}}";
@@ -40,9 +39,20 @@
 
       extraOptions = [
         "--pull=always"
+        # {% if component.backend == "podman" %}
+        "--cgroups=enabled"
+        "--cidfile=/run/{{component.container_name}}/ctr-id"
+        # {% endif %}
         # {% for option in (component.extra_options or []) %}
         "{{option}}"
         # {% endfor %}
+        # {% if component.backend == "podman" %}
+        "--sdnotify=healthy"
+        # {% endif %}
+        # {% if component.health_cmd %}
+        "--health-cmd"
+        {{ component.health_cmd }}
+        # {% endif %}
       ];
 
       volumes = [
@@ -68,4 +78,16 @@
       ];
     };
   };
+
+  # {% if component.backend == "podman" %}
+  systemd.services."podman-{{ component.container_name }}".serviceConfig = {
+    User = "{{ component.user }}";
+    RuntimeDirectory = "{{component.container_name}}";
+    Delegate = true;
+    NotifyAccess = "all";
+  };
+
+  systemd.services."podman-{{ component.container_name }}".wants = [ "linger-users.service" ];
+  users.users."{{ component.user }}".linger = true;
+  # {% endif %}
 }


### PR DESCRIPTION
FC-37959

We mostly want this for healthchecks that must pass before the unit is actually active.