### PR TITLE
[FC-42677] file: add `file_name` attribute to `DeploymentTrash`

### DIFF
--- a/CHANGES.d/20241227_105603_mb_FC_42677_fix_multiple_deploymenttrash.md
+++ b/CHANGES.d/20241227_105603_mb_FC_42677_fix_multiple_deploymenttrash.md
@@ -1,0 +1,1 @@
+- Allow to configure the name of the `.nix` file created by `batou_ext.file.DeploymentTrash`.

--- a/src/batou_ext/file.py
+++ b/src/batou_ext/file.py
@@ -42,6 +42,7 @@ class SymlinkAndCleanup(batou.component.Component):
     systemd_read_max_iops = 100
     systemd_write_max_iops = 100
     trashdir = None
+    trash_config_file_name = batou.component.Attribute(str, default="trash.nix")
 
     ## DEPRECATED, do not use
     use_systemd_run_async_cleanup = False
@@ -58,6 +59,7 @@ class SymlinkAndCleanup(batou.component.Component):
             read_iops_limit=self.systemd_read_max_iops,
             write_iops_limit=self.systemd_write_max_iops,
             trashdir=self.trashdir,
+            file_name=self.trash_config_file_name,
         )
         self.trash = self._
 
@@ -170,6 +172,8 @@ class DeploymentTrash(batou.component.Component):
     ```
     """
 
+    file_name = batou.component.Attribute(str, default="trash.nix")
+
     read_iops_limit = 100
     write_iops_limit = 100
 
@@ -181,7 +185,7 @@ class DeploymentTrash(batou.component.Component):
 
         self += batou.lib.file.File(self.trashdir, ensure="directory")
         self += batou.lib.file.File(
-            "/etc/local/nixos/trash.nix",
+            f"/etc/local/nixos/{self.file_name}",
             content=dedent(
                 """\
             {


### PR DESCRIPTION
Fixes #209

This won't work for multiple deployments on the same host using all the same file since all of those deployments will override each other's trash.nix (or fail trying if each deployment uses its own service user).