### PR TITLE
[FC-42763] fix multiple trash dirs on one vm

### DIFF
--- a/CHANGES.d/20250107_144004_ph_FC_42763_support_multiple_trash_units_on_one_vm.md
+++ b/CHANGES.d/20250107_144004_ph_FC_42763_support_multiple_trash_units_on_one_vm.md
@@ -1,0 +1,2 @@
+- Fix using multiple DeploymentTrash Component on a single host breaking the Nix rebuild, especially across different deployments to the same machine.
+  This was because the values for the IOPS read and write Limits in the Systemd serviceConfig attribute set were defined as strings (which cannot be merged unless identical) instead of lists (which can always be merged).

--- a/src/batou_ext/file.py
+++ b/src/batou_ext/file.py
@@ -194,8 +194,8 @@ class DeploymentTrash(batou.component.Component):
               ];
 
               systemd.services."systemd-tmpfiles-clean".serviceConfig = {
-                IOReadIOPSMax="{{component.trashdir}} {{component.read_iops_limit}}";
-                IOWriteIOPSMax="{{component.trashdir}} {{component.write_iops_limit}}";
+                IOReadIOPSMax=["{{component.trashdir}} {{component.read_iops_limit}}"];
+                IOWriteIOPSMax=["{{component.trashdir}} {{component.write_iops_limit}}"];
               };
             }
         """


### PR DESCRIPTION
Adjust the merging behaviour of the `serviceConfig` option value by defining the values as lists so that multiple trash directories can be defined per VM.

Previously, multiple definitions would collide when merging since they differ. Defining the value as a list makes the option's values mergeable in the indended way.