### PR TITLE
[FC-20956] batou_ext.fcio: Add components that set an RG in maintenance for the time of the deployment

### DIFF
--- a/CHANGES.d/20250117_111031_mb_FC_20956_enter_leave_maintenance.md
+++ b/CHANGES.d/20250117_111031_mb_FC_20956_enter_leave_maintenance.md
@@ -1,0 +1,3 @@
+- Added `batou_ext.fcio.Maintenance{Start,End}`: with these components it's possible to mark the RG
+  as "in maintenance". Components can be scheduled between these two by doing
+  `self.provide("needs-maintenance", self)`.

--- a/CHANGES.d/20250212_162509_mb_FC_20956_enter_leave_maintenance.md
+++ b/CHANGES.d/20250212_162509_mb_FC_20956_enter_leave_maintenance.md
@@ -1,0 +1,3 @@
+- The components `batou_ext.fcio.{MaintenanceStart,MaintenanceEnd,DirectoryXMLRPC}` were added to
+  put a resource group into maintenance for a deployment. Please read the doc comment
+  of `batou_ext.fcio.MaintenanceStart` for further reference.

--- a/src/batou_ext/tests/test_configure.py
+++ b/src/batou_ext/tests/test_configure.py
@@ -93,6 +93,11 @@ class MockRoundcubeProvider(Component):
         self.provide("roundcube::database", self)
 
 
+class MockXMLRPCProvider(Component):
+    def configure(self):
+        self.provide("directory-xmlrpc", self)
+
+
 def test_prepare(root, mocker, component, tmpdir):
     """Assert that the `prepare` method of batou_ext components can be called.
 
@@ -172,6 +177,16 @@ def test_prepare(root, mocker, component, tmpdir):
         instance.script = "/srv/s-myuser/start-application.sh"
         instance.watchdog_script_path = "/srv/s-myuser/watchdog-wrapper.py"
         instance.healthcheck_url = "https://example.com"
+    elif component_name in {
+        "batou_ext.fcio.MaintenanceStart",
+        "batou_ext.fcio.MaintenanceEnd",
+    }:
+        MockXMLRPCProvider().prepare(root)
+    elif component_name == "batou_ext.fcio.DirectoryXMLRPC":
+        root.environment.overrides["provision"] = {
+            "project": "foo",
+            "api_key": "aligator3",
+        }
     elif component_name == "batou_ext.mail.Mailpit":
         batou_ext.http.HTTPBasicAuth(
             **batou_ext.http.HTTPBasicAuth._required_params_


### PR DESCRIPTION
Given a `provision` section in the secret config like

```ini
[provision]
project = test
api_key = <redacted>
```

an environment config like this

```ini
[host:test42]
components =
  demo
  directoryxmlrpc
  maintenancestart
  maintenanceend
```

and a component like this

```python
class Demo(Component):
  def configure(self):
    self.provide("needs-maintenance", self)
    self += File("foobar")
```

then all subcomponents configured by `Demo will be deployed while the RG is in maintenance.