### PR TITLE
[FC-41030] batou_ext.file.SymlinkAndCleanup: add option "etag_suffix"

### DIFF
--- a/CHANGES.d/20250122_125537_mb_FC_41030_etag_cleanup.md
+++ b/CHANGES.d/20250122_125537_mb_FC_41030_etag_cleanup.md
@@ -1,0 +1,7 @@
+- `batou_ext.file.SymlinkAndCleanup`: add option `etag_suffix`.
+  This contains a suffix that each symlinked file may have.
+
+  For instance, when doing `SymlinkAndCleanup` on a file downloaded with
+  `batou_ext.s3.Download`, the pattern `*.tar.gz` doesn't clean up the
+  `.etag` files. However, `*.tar.gz*` (or an equivalent) would also remove
+  the etag files of the files that are symlinked to `current` & `last`.

--- a/src/batou_ext/file.py
+++ b/src/batou_ext/file.py
@@ -34,6 +34,7 @@ class SymlinkAndCleanup(batou.component.Component):
 
     namevar = "current"
     pattern = None
+    etag_suffix = batou.component.Attribute(str, ".etag")
     _current_link = None
     _last_link = None
 
@@ -92,6 +93,7 @@ class SymlinkAndCleanup(batou.component.Component):
 
     def _list_removals(self):
         candidates = glob.glob(self.pattern)
+        candidates.extend(glob.glob(self.pattern + self.etag_suffix))
 
         current = self._link(self._current_link)
         last = self._link(self._last_link)
@@ -99,10 +101,18 @@ class SymlinkAndCleanup(batou.component.Component):
             # keep last+current
             self.remove(candidates, current)
             self.remove(candidates, last)
+            if current is not None:
+                self.remove(candidates, current + self.etag_suffix)
+            if last is not None:
+                self.remove(candidates, last + self.etag_suffix)
         else:
             # keep current + new current"
             self.remove(candidates, current)
             self.remove(candidates, self.current)
+            if current is not None:
+                self.remove(candidates, current + self.etag_suffix)
+            if self.current is not None:
+                self.remove(candidates, self.current + self.etag_suffix)
 
         return candidates
 


### PR DESCRIPTION
Given the following deployment:

    self += s3.Download(..., target=f"{version}.tar.gz")
    archive = self._.target
    self += SymlinkAndCleanup(target, pattern="*.tar.gz")

With this, the tarballs that are neither linked by `last` or `current` are removed. However, the `.etag` files from `s3.Download` are not.

Doing `pattern="*.tar.gz*"` is not an option here since this would remove ALL etag files. This means that the next deployment would download the tarball from S3 again since its etag file is missing.

This patch adds an attribute called `etag_suffix` that tries to delete all files matching the glob pattern `pattern + etag_suffix` unless `pattern` is equal to the file linked by current or last.