### PR TITLE
oci: set backend explicitly

### DIFF
--- a/CHANGES.d/20250228_091738_mb_FC_43611_oci_backend_explicit.md
+++ b/CHANGES.d/20250228_091738_mb_FC_43611_oci_backend_explicit.md
@@ -1,0 +1,4 @@
+- `batou_ext.oci.Container`: set `backend` explicitly in Nix expression.
+
+  Otherwise this depends on the state version having varying results depending on whether
+  the machine was installed with a NixOS older or newer than 22.05.

--- a/src/batou_ext/resources/oci-template.nix
+++ b/src/batou_ext/resources/oci-template.nix
@@ -17,6 +17,7 @@
   # {% endif %}
 
   virtualisation.oci-containers = {
+    backend = "{{ component.backend }}";
     containers."{{component.container_name}}" = {
       # {% if component.entrypoint %}
       entrypoint = "{{component.entrypoint}}";


### PR DESCRIPTION
FC-43611

Given we decide per-machine which backend to use with `PodmanRuntime`, this won't result in conflicting definitions[1].

We actually have to make this explicit, otherwise this is decided by the state version. I.e. it depends on whether 22.05 or older was the first NixOS installed.

[1] Unless you remove a container without removing the `.nix` file and
    changing the backend for the rest after that. But that's IMHO a bug
    in the deployment code then.