### PR TITLE
oci: make sure user session doesn't get stopped before container on shutdown

### DIFF
--- a/CHANGES.d/20250328_160618_mb_podman_fixup_tmpfiles.md
+++ b/CHANGES.d/20250328_160618_mb_podman_fixup_tmpfiles.md
@@ -1,0 +1,3 @@
+- oci: make `user@uid.service` wait until all containers have exited and clear `/tmp` of containers.
+  Without those, unclean shutdowns were observed that prevented the containers from getting back
+  up on a reboot.


### PR DESCRIPTION
This seems to have caused unclean shutdowns with errors on containers like

    Error: current system boot ID differs from cached boot ID; an unhandled reboot has occurred.

when getting back up.

This seems related to the user unit being stopped too early preventing a clean stop. Hence, the dependencies were updated accordingly for podman units.

Also using `PrivateTmp` now for the containers, i.e. the `/tmp` part is hidden in `/tmp/systemd-private-*/tmp`. Also, `systemd` will clear this directory when the unit gets stopped which was the direct cause of the error mentioned above. From `systemd.exec(5)`:

> If true, all temporary files created by a service
> in these directories will be removed after the service is stopped.