### PR TITLE
[FC-45607] Remove deprecated pkg_resources

### DIFF
--- a/CHANGES.d/20250623_105812_nm_FC_45607_batou_ext__Remove_pkg_resources.md
+++ b/CHANGES.d/20250623_105812_nm_FC_45607_batou_ext__Remove_pkg_resources.md
@@ -1,0 +1,1 @@
+- Remove deprecated pkg_resources and replace with importlib.resources

--- a/src/batou_ext/cron.py
+++ b/src/batou_ext/cron.py
@@ -1,8 +1,8 @@
+from importlib.resources import files
 from textwrap import dedent
 
 import batou.component
 import batou.lib.nagios
-import pkg_resources
 
 
 class CronJob(batou.component.Component):
@@ -87,9 +87,9 @@ class CronJob(batou.component.Component):
 
         self += batou.lib.file.File(
             self.expand("{{component.tag}}.sh"),
-            content=pkg_resources.resource_string(
-                __name__, "resources/cron-wrapper.sh"
-            ),
+            content=(
+                files(__spec__.parent) / "resources/cron-wrapper.sh"
+            ).read_bytes(),
             mode=0o755,
         )
         self.wrapped_command = self._.path
@@ -215,9 +215,9 @@ class SystemdTimer(batou.component.Component):
 
         self += batou.lib.file.File(
             self.expand("check_systemd_unit.py"),
-            content=pkg_resources.resource_string(
-                __name__, "resources/check_systemd_unit.py"
-            ),
+            content=(
+                files(__spec__.parent) / "resources/check_systemd_unit.py"
+            ).read_bytes(),
             mode=0o755,
         )
         self.check_command = self._.path

--- a/src/batou_ext/http.py
+++ b/src/batou_ext/http.py
@@ -1,6 +1,7 @@
+from importlib.resources import files
+
 import batou.component
 import batou.lib.file
-import pkg_resources
 
 import batou_ext.nix
 
@@ -222,9 +223,9 @@ class HTTPServiceWatchdog(batou.component.Component):
 
         self += batou.lib.file.File(
             f"/etc/local/nixos/{self.service}-watchdog.nix",
-            content=pkg_resources.resource_string(
-                __name__, "resources/http-watchdog.nix"
-            ),
+            content=(
+                files(__spec__.parent) / "resources/http-watchdog.nix"
+            ).read_bytes(),
         )
 
         if self.rebuild:
@@ -241,8 +242,8 @@ class HTTPWatchdogScript(batou.component.Component):
         self += batou.lib.file.File(
             "watchdog-wrapper.py",
             mode=0o755,
-            content=pkg_resources.resource_string(
-                __name__, "resources/watchdog-wrapper.py"
-            ),
+            content=(
+                files(__spec__.parent) / "resources/watchdog-wrapper.py"
+            ).read_bytes(),
         )
         self.path = self._.path

--- a/src/batou_ext/journalbeat.py
+++ b/src/batou_ext/journalbeat.py
@@ -1,6 +1,7 @@
+from importlib.resources import files
+
 import batou.component
 import batou.lib.file
-import pkg_resources
 
 
 class JournalBeatTransport(batou.component.Component):
@@ -18,7 +19,7 @@ class JournalBeatTransport(batou.component.Component):
 
         self += batou.lib.file.File(
             self.nix_file_path,
-            content=pkg_resources.resource_string(
-                __name__, "resources/journalbeat.nix"
-            ),
+            content=(
+                files(__spec__.parent) / "resources/journalbeat.nix"
+            ).read_bytes(),
         )

--- a/src/batou_ext/mail.py
+++ b/src/batou_ext/mail.py
@@ -1,8 +1,8 @@
+from importlib.resources import files
 from textwrap import dedent
 
 import batou.component
 import batou.lib.file
-import pkg_resources
 
 import batou_ext.nix
 import batou_ext.ssl
@@ -161,9 +161,9 @@ class Mailhog(batou.component.Component):
 
         self += batou.lib.file.File(
             "/etc/local/nixos/mailhog.nix",
-            content=pkg_resources.resource_string(
-                __name__, "resources/mailhog/mailhog.nix"
-            ),
+            content=(
+                files(__spec__.parent) / "resources/mailhog/mailhog.nix"
+            ).read_bytes(),
         )
 
 
@@ -202,7 +202,7 @@ class Mailpit(batou.component.Component):
 
         self += batou.lib.file.File(
             "/etc/local/nixos/mailpit.nix",
-            content=pkg_resources.resource_string(
-                __name__, "resources/mailpit.nix"
-            ),
+            content=(
+                files(__spec__.parent) / "resources/mailpit.nix"
+            ).read_bytes(),
         )

--- a/src/batou_ext/php.py
+++ b/src/batou_ext/php.py
@@ -22,10 +22,10 @@ Example for NixOS::
 
 import hashlib
 import os.path
+from importlib.resources import files
 
 import batou.component
 import batou.lib.file
-import pkg_resources
 
 
 class Ini(batou.component.Component):
@@ -52,9 +52,9 @@ class Ini(batou.component.Component):
         # Providing a php.ini
         self += batou.lib.file.File(
             "php.ini",
-            content=pkg_resources.resource_string(
-                __name__, "resources/php/php.ini"
-            ),
+            content=(
+                files(__spec__.parent) / "resources/php/php.ini"
+            ).read_bytes(),
         )
         self.php_ini = self._
 
@@ -112,9 +112,9 @@ class FPM(batou.component.Component):
 
         self += batou.lib.file.File(
             "php-fpm.conf",
-            content=pkg_resources.resource_string(
-                __name__, "resources/php/php-fpm.conf"
-            ),
+            content=(
+                files(__spec__.parent) / "resources/php/php-fpm.conf"
+            ).read_bytes(),
         )
         self._checksum.update(self._.content)
         self.php_fpm_ini = self._.path
@@ -127,9 +127,9 @@ class FPM(batou.component.Component):
         self += batou.lib.file.File(
             self.name,
             mode=0o755,
-            content=pkg_resources.resource_string(
-                __name__, "resources/php/php-fpm.sh"
-            ),
+            content=(
+                files(__spec__.parent) / "resources/php/php-fpm.sh"
+            ).read_bytes(),
         )
         self._checksum.update(self._.content)
 

--- a/src/batou_ext/python.py
+++ b/src/batou_ext/python.py
@@ -43,7 +43,7 @@ class Pipenv(batou.component.Component):
             # Is this Python (still) functional 'enough'
             # from a setuptools/distribute perspective?
             self.assert_cmd(
-                '{{component.executable}} -c "import pkg_resources"'
+                '{{component.executable}} -c "from importlib.resources import files"'
             )
 
     def update(self):

--- a/src/batou_ext/ssl.py
+++ b/src/batou_ext/ssl.py
@@ -2,13 +2,13 @@ import hashlib
 import os
 import os.path
 import tempfile
+from importlib.resources import files
 
 import batou.component
 import batou.lib.cron
 import batou.lib.download
 import batou.lib.file
 import batou.lib.nagios
-import pkg_resources
 import six
 
 from .acl import ACL
@@ -209,9 +209,9 @@ KEY_ALGO={{component.dehydrated_publickey_algo}}
 
             self += batou.lib.file.File(
                 self.expand("cert-{{component.domain}}.sh"),
-                content=pkg_resources.resource_string(
-                    "batou_ext", "resources/cert.sh"
-                ),
+                content=(
+                    files(__spec__.parent) / "resources/cert.sh"
+                ).read_bytes(),
                 mode=0o700,
             )
             self.cert_sh = self._
@@ -339,9 +339,10 @@ class CertificateCheckLocal(batou.component.Component):
 
         self += batou.lib.file.File(
             "cert_check_{}.sh".format(self.name),
-            content=pkg_resources.resource_string(
-                __name__, "resources/ssl/local_certificate_check.sh"
-            ),
+            content=(
+                files(__spec__.parent)
+                / "resources/ssl/local_certificate_check.sh"
+            ).read_bytes(),
             mode=0o755,
         )
         self.script = self._.path

--- a/src/batou_ext/systemd.py
+++ b/src/batou_ext/systemd.py
@@ -1,4 +1,5 @@
-import pkg_resources
+from importlib.resources import files
+
 from batou.component import Attribute, Component
 from batou.lib.file import File
 
@@ -75,9 +76,9 @@ class ScalableService(Component):
     def configure(self):
         self += File(
             f"/etc/local/nixos/scale-{self.base_name}.nix",
-            content=pkg_resources.resource_string(
-                "batou_ext", "resources/scalable-service.nix"
-            ),
+            content=(
+                files(__spec__.parent) / "resources/scalable-service.nix"
+            ).read_bytes(),
         )
 
         self.unit_identifier = f"{self.base_name}@"


### PR DESCRIPTION
Use importlib.resources instead. Pytest run and batou deployment were successful.