### PR TITLE
[FC-46208] oci: fix eval on 25.05

### DIFF
--- a/CHANGES.d/20250626_110712_mb_FC_46208_podman_25_05.md
+++ b/CHANGES.d/20250626_110712_mb_FC_46208_podman_25_05.md
@@ -1,0 +1,1 @@
+- Fixed compatibility of `batou_ext.oci` with `podman` backend and NixOS 25.05.

--- a/src/batou_ext/resources/oci-template.nix
+++ b/src/batou_ext/resources/oci-template.nix
@@ -1,4 +1,4 @@
-{ config, ... }:
+{ lib, config, ... }:
 {
   # {% if component.monitor %}
   flyingcircus = {
@@ -89,7 +89,7 @@
     after = [ "user@${toString uid}.service" ];
     unitConfig.RequiresMountsFor = "/run/user/${toString uid}/containers";
     serviceConfig = {
-      User = "{{ component.user }}";
+      User = lib.mkForce "{{ component.user }}";
       RuntimeDirectory = "{{component.container_name}}";
       Delegate = true;
       NotifyAccess = "all";


### PR DESCRIPTION
On 25.05 there's a dedicated `podman.user` option I added for exactly what we implemented here.

We should start using this eventually, but for now we work around this since the vast majority of our VMs is running 24.11/24.05, so forcing 25.05 on the next patch-level is a little excessive.