### PR TITLE
[FC-44942] ssh: support multiple ssh keys per deployment

### DIFF
--- a/CHANGES.d/20250826_110130_mb_FC_44942_multiple_ssh_keypair_components.md
+++ b/CHANGES.d/20250826_110130_mb_FC_44942_multiple_ssh_keypair_components.md
@@ -1,0 +1,2 @@
+- Add options `file_name` and `provide_as` to `batou_ext.ssh.SSHKeyPair`. With this, it's possible to add multiple
+  SSH keys into a deployment.


### PR DESCRIPTION
Right now, it's possible to only add two keys per deployment (with the attributes id_ed25519 and id_rsa). Now that we have more applications that we pull from GitHub which only allows a key to be used once, we need a way to enroll multiple SSH keys in a deployment.

This is done via `file_name`. When used, it's possible to add either a id_ed25519 or a id_rsa, but not both.