### PR TITLE
Add `python.BuildEnv` to provide python virtual env support on nixos.

### DIFF
--- a/CHANGES.d/20250828_092915_cz_add_build_python_env.md
+++ b/CHANGES.d/20250828_092915_cz_add_build_python_env.md
@@ -1,0 +1,3 @@
+- Add `python.BuildEnv` to provide python virtual env support on nixos.
+
+  The component helps to build venvs with classic requirements.txt so that one does not need to package everything for nixos.


### PR DESCRIPTION
The component helps to build venvs with classic requirements.txt so that one does not need to package everything for nixos.