### PR TITLE
Improvements to postfix relay

### DIFF
--- a/CHANGES.d/20260505_084612_cz_mail_relay_improvments.md
+++ b/CHANGES.d/20260505_084612_cz_mail_relay_improvments.md
@@ -1,0 +1,3 @@
+- PostfixRelay: Fix setting of relay hostname to not require `[]`.
+- PostfixRelay: Allow to set `my_networks`.
+- PostfixRelay: Modernise config: use `smtp_tls_security_level`

--- a/src/batou_ext/mail.py
+++ b/src/batou_ext/mail.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 
 import batou.component
 import batou.lib.file
+import batou.utils
 
 import batou_ext.nix
 import batou_ext.ssl
@@ -30,12 +31,19 @@ class PostfixRelay(batou.component.Component):
     smtp_user = batou.component.Attribute(str)
     smtp_password = batou.component.Attribute(str)
 
+    my_networks = batou.component.Attribute("list", default=[])
+    """Overwrite default mynetworks from service.
+
+    This allows to e.g. to send mail from docker containers.
+    """
+
     provide_as = None  # (optional) str to self.provide()
 
     def configure(self):
         if self.provide_as:
             self.provide(self.provide_as, self)
         self.address = batou.utils.Address(self.host.fqdn, 25, require_v6=True)
+
         self += batou.lib.file.File(
             "/etc/local/nixos/postfix-relay.nix",
             content=dedent(
@@ -43,18 +51,25 @@ class PostfixRelay(batou.component.Component):
                     """
                     {
                         services.postfix.settings.main = {
-                            relayhost = ["{{component.smtp_relay_host}}:{{component.smtp_relay_port}}"];
+                            relayhost = ["[{{component.smtp_relay_host}}]:{{component.smtp_relay_port}}"];
                             {% if component.smtp_auth %}
                             smtp_sasl_auth_enable = "yes";
                             smtp_sasl_password_maps = "hash:/etc/local/postfix/sasl_passwd";
                             smtp_sasl_security_options = "noanonymous";
-                            {% endif %}
+                            {%- endif %}
                             {% if component.smtp_tls %}
-                            smtp_use_tls = "yes";
-                            {% endif %}
+                            smtp_tls_security_level = "encrypt";
+                            {%- endif %}
+                            {% if component.my_networks %}
+                            mynetworks = [
+                              {%- for network in component.my_networks %}
+                              "{{network}}"
+                              {%- endfor %}
+                            ];
+                            {%- endif %}
                         };
                     }
-    """
+                    """
                 )
             ),
         )

--- a/src/batou_ext/tests/test_mail.py
+++ b/src/batou_ext/tests/test_mail.py
@@ -1,0 +1,80 @@
+import pytest
+
+from batou_ext.mail import PostfixRelay
+
+
+def _get_nix_content(relay):
+    return relay.sub_components[0].content.decode()
+
+
+@pytest.fixture
+def relay(root):
+    r = PostfixRelay(
+        smtp_relay_host="smtp.example.com",
+        smtp_user="scott",
+        smtp_password="tiger",
+    )
+    r.prepare(root)
+    return r
+
+
+def test_relay_host_without_brackets(relay):
+    assert relay.smtp_relay_host == "smtp.example.com"
+
+
+def test_nix_config_contains_bracketed_relayhost(relay):
+    content = _get_nix_content(relay)
+    assert '"[smtp.example.com]:587"' in content
+
+
+def test_nix_config_contains_smtp_tls_security_level(relay):
+    content = _get_nix_content(relay)
+    assert 'smtp_tls_security_level = "encrypt"' in content
+    assert "smtp_use_tls" not in content
+
+
+def test_nix_config_no_tls_when_disabled(root):
+    r = PostfixRelay(
+        smtp_relay_host="smtp.example.com",
+        smtp_user="scott",
+        smtp_password="tiger",
+    )
+    r.smtp_tls = False
+    r.prepare(root)
+    content = _get_nix_content(r)
+    assert "smtp_tls_security_level" not in content
+
+
+def test_nix_config_my_networks_empty_by_default(relay):
+    content = _get_nix_content(relay)
+    assert "mynetworks" not in content
+
+
+def test_nix_config_my_networks_set(root):
+    r = PostfixRelay(
+        smtp_relay_host="smtp.example.com",
+        smtp_user="scott",
+        smtp_password="tiger",
+        my_networks=["10.0.0.0/8", "172.16.0.0/12"],
+    )
+    r.prepare(root)
+    content = _get_nix_content(r)
+    assert "10.0.0.0/8" in content
+    assert "172.16.0.0/12" in content
+
+
+def test_nix_config_no_auth_skips_sasl(relay):
+    content = _get_nix_content(relay)
+    assert "smtp_sasl_auth_enable" in content
+
+
+def test_nix_config_no_auth_when_disabled(root):
+    r = PostfixRelay(
+        smtp_relay_host="smtp.example.com",
+        smtp_user="scott",
+        smtp_password="tiger",
+    )
+    r.smtp_auth = False
+    r.prepare(root)
+    content = _get_nix_content(r)
+    assert "smtp_sasl_auth_enable" not in content


### PR DESCRIPTION
- PostfixRelay: Fix setting of relay hostname to not require `[]`.
- PostfixRelay: Allow to set `my_networks`.
- PostfixRelay: Modernise config: use `smtp_tls_security_level`